### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -48,13 +48,17 @@ public class Servers {
   @ResponseBody
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name: " + column);
+    }
 
     try (var connection = dataSource.getConnection()) {
       try (var statement =
           connection.prepareStatement(
               "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+                  + " of order' order by " + column)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/Javi-l10/ucmdxc_WebGoat/security/code-scanning/42](https://github.com/Javi-l10/ucmdxc_WebGoat/security/code-scanning/42)

To fix the problem, we need to avoid using string concatenation to build the SQL query with user input. Instead, we should use a prepared statement with parameterized queries. However, since the `column` parameter is used to specify the column to sort by, we cannot directly use a placeholder for column names in prepared statements. Therefore, we need to validate the `column` parameter against a whitelist of allowed column names to ensure it is safe to use in the query.

1. Create a list of allowed column names.
2. Validate the `column` parameter against this list.
3. If the `column` parameter is valid, proceed with constructing the query using the validated column name.
4. If the `column` parameter is not valid, handle the error appropriately (e.g., return an error response).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
